### PR TITLE
Fix reasons section layout for Firefox

### DIFF
--- a/css/landing_crystals.css
+++ b/css/landing_crystals.css
@@ -784,7 +784,7 @@ footer .disclaimer {
     text-align: left;
     padding: 0px;
     position: relative;
-    min-height: 140px;
+    height: 140px;
     float: left;
     width: calc(50% - 2em);
     display: table;

--- a/css/landing_gradient.css
+++ b/css/landing_gradient.css
@@ -784,7 +784,7 @@ footer .disclaimer {
     text-align: left;
     padding: 0px;
     position: relative;
-    min-height: 140px;
+    height: 140px;
     float: left;
     width: calc(50% - 2em);
     display: table;

--- a/css/landing_portrait.css
+++ b/css/landing_portrait.css
@@ -794,7 +794,7 @@ footer .disclaimer {
     text-align: left;
     padding: 0px;
     position: relative;
-    min-height: 140px;
+    height: 140px;
     float: left;
     width: calc(50% - 2em);
     display: table;


### PR DESCRIPTION
Use `height` instead of `min-height`.