### PR TITLE
Remove pointer from #team figure tag

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -318,7 +318,6 @@ aside.contact-form-wrapper > p.disclaimer {
 
 #team figure {
   position: relative;
-  cursor: pointer;
   margin: 0;
 }
 


### PR DESCRIPTION
[trello card](https://trello.com/c/QXqf59iM) 

> jak masz zespół, to na hover najeżdżają te niebieskie warstwy i one same w sobie są nieklikalne, a kursor się na nich zmienia na pointer. A pointer się powinien robić dopiero po najechaniu na logo twittera/githuba - w dużym uproszeniu może to zmylić, zwłaszcza jak jest tylko jedno logo/link lub zero